### PR TITLE
Add server initialization variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.wix</groupId>
     <artifactId>wix-embedded-mysql-modules</artifactId>
-    <version>4.6.3-SNAPSHOT</version>
+    <version>4.6.4-SNAPSHOT</version>
     <name>Wix Embedded MySql Modules aggregator</name>
     <description>Wix Embedded MySql Modules aggregator</description>
     <url>https://github.com/wix/wix-embedded-mysql</url>
@@ -177,6 +177,7 @@
     </profiles>
 
     <distributionManagement>
+
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>

--- a/wix-embedded-mysql-download-and-extract/pom.xml
+++ b/wix-embedded-mysql-download-and-extract/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wix</groupId>
     <artifactId>wix-embedded-mysql-download-and-extract</artifactId>
-    <version>4.6.3-SNAPSHOT</version>
+    <version>4.6.4-SNAPSHOT</version>
     <name>Wix Embedded Mysql Download and Extract</name>
     <description>Cli tool to predownload/precache mysql artifacts for wix-embedded-mysql</description>
     <url>https://github.com/wix/wix-embedded-mysql/tree/master/wix-embedded-mysql-download-and-extract</url>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.wix</groupId>
         <artifactId>wix-embedded-mysql-modules</artifactId>
-        <version>4.6.3-SNAPSHOT</version>
+        <version>4.6.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.wix</groupId>
             <artifactId>wix-embedded-mysql</artifactId>
-            <version>4.6.3-SNAPSHOT</version>
+            <version>4.6.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -65,7 +65,7 @@
         </dependency>
 
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/wix-embedded-mysql/pom.xml
+++ b/wix-embedded-mysql/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.wix</groupId>
     <artifactId>wix-embedded-mysql</artifactId>
-    <version>4.6.3-SNAPSHOT</version>
+    <version>4.6.4-SNAPSHOT</version>
     <name>Wix Embedded MySql</name>
     <description>Embedded MySql for E2E/IT tests</description>
     <url>https://github.com/wix/wix-embedded-mysql/tree/master/wix-embedded-mysql</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.wix</groupId>
         <artifactId>wix-embedded-mysql-modules</artifactId>
-        <version>4.6.3-SNAPSHOT</version>
+        <version>4.6.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/config/MysqldConfig.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/config/MysqldConfig.java
@@ -157,6 +157,21 @@ public class MysqldConfig extends ExecutableProcessConfig {
             return withTimeZone(TimeZone.getTimeZone(timeZoneId));
         }
 
+        public Builder withInitServerVariable(String name, boolean value) {
+            this.serverVariables.add(new ServerVariable<>(true, name, value));
+            return this;
+        }
+
+        public Builder withInitServerVariable(String name, int value) {
+            this.serverVariables.add(new ServerVariable<>(true, name, value));
+            return this;
+        }
+
+        public Builder withInitServerVariable(String name, String value) {
+            this.serverVariables.add(new ServerVariable<>(true, name, value));
+            return this;
+        }
+
         /**
          * Provide mysql server option
          *
@@ -233,12 +248,24 @@ public class MysqldConfig extends ExecutableProcessConfig {
     }
 
     public static class ServerVariable<T> {
+        private final boolean initializer;
         private final String name;
         private final T value;
 
-        ServerVariable(final String name, final T value) {
+        ServerVariable(final boolean initializer, final String name, final T value) {
+            this.initializer = initializer;
             this.name = name;
             this.value = value;
+        }
+
+        ServerVariable(final String name, final T value) {
+            this.initializer = false;
+            this.name = name;
+            this.value = value;
+        }
+
+        public boolean isInitializer() {
+            return initializer;
         }
 
         public String toCommandLineArgument() {

--- a/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/setup/Mysql8Initializer.java
+++ b/wix-embedded-mysql/src/main/java/com/wix/mysql/distribution/setup/Mysql8Initializer.java
@@ -1,6 +1,7 @@
 package com.wix.mysql.distribution.setup;
 
 import com.wix.mysql.config.MysqldConfig;
+import com.wix.mysql.config.MysqldConfig.ServerVariable;
 import com.wix.mysql.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.extract.IExtractedFileSet;
@@ -8,6 +9,9 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -23,12 +27,20 @@ public class Mysql8Initializer implements Initializer {
         File baseDir = files.baseDir();
         FileUtils.deleteDirectory(new File(baseDir, "data"));
 
-        Process p = Runtime.getRuntime().exec(new String[]{
-                files.executable().getAbsolutePath(),
-                "--no-defaults",
-                "--initialize-insecure",
-                format("--basedir=%s", baseDir),
-                format("--datadir=%s/data", baseDir)});
+        List<String> systemVariables = new ArrayList<>();
+        systemVariables.add(files.executable().getAbsolutePath());
+        systemVariables.add("--no-defaults");
+        systemVariables.add("--initialize-insecure");
+        systemVariables.add(format("--basedir=%s", baseDir));
+        systemVariables.add(format("--datadir=%s/data", baseDir));
+
+        List<String> configSystemVariables = config.getServerVariables().stream()
+                .filter(ServerVariable::isInitializer)
+                .map(ServerVariable::toCommandLineArgument)
+                .collect(Collectors.toList());
+        systemVariables.addAll(configSystemVariables);
+
+        Process p = Runtime.getRuntime().exec(systemVariables.toArray(new String[0]));
 
         new ProcessRunner(files.executable().getAbsolutePath()).run(p, runtimeConfig, config.getTimeout(NANOSECONDS));
     }


### PR DESCRIPTION
Adds a server variable that is used to initialize the server.

This is not a perfect solution as it will use the same Server Variable when initializing MySQL and when booting it up... as if there's a difference between both things.

Anyways, this is only useful when setting `--lower_case_table_names=1` on Mac OS X as you need it in both places, `MySQL8Initializer.java` and `AbstractProcess.java`.  Setting it in one without the other throws an error.